### PR TITLE
create migration for images table and run migrate

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,5 @@
+class Image < ApplicationRecord
+  validates :title, uniqueness: true
+
+  belongs_to :admin, class_name: :User, foreign_key: :user_id, optional: true
+end

--- a/db/migrate/20191129010432_create_images.rb
+++ b/db/migrate/20191129010432_create_images.rb
@@ -1,7 +1,7 @@
 class CreateImages < ActiveRecord::Migration[6.0]
   def change
     create_table :images do |t|
-      t.references :user, null: false, foreign_key: true
+      t.references :user, foreign_key: true, null: true
       t.string :title, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2019_11_29_010432) do
   end
 
   create_table "images", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.string "title", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
resolves #6 

adds an image table with foreign keys for the user who uploaded any given image

seems like it could eventually include a foreign key on some sort of author model, too, but it's not immediately clear the right way to model an author in this scope as normalized records that correspond to the authors' twitter accounts (ie not handles or display names which obviously change)